### PR TITLE
#20 refactored some tests and updated some Test dependencies

### DIFF
--- a/Library.Tests/Broadcast/LanService_WhenNotThrottled_Should.cs
+++ b/Library.Tests/Broadcast/LanService_WhenNotThrottled_Should.cs
@@ -52,25 +52,25 @@ namespace Library.Tests.Broadcast
         }
 
         [Fact]
-        public void Broadcast_StartsNewDequeueTask()
+        public void StartBroadcast_SetsNewDequeueTask()
         {
             //assemble
             _mockLanRepository.ResetCalls();
 
             //act
-            _lanService.Broadcast(It.IsAny<byte[]>());
+            _lanService.StartBroadcast();
             //assert
             _mockLanRepository.VerifySet(lr => lr.DequeueTask = It.IsAny<Task>());
         }
-
+        
         [Fact]
-        public void StartDeque_StartsNewDequeueTask()
+        public void SStartBroadcast_StartsNewDequeueTask()
         {
             //assemble
             _mockLanRepository.ResetCalls();
 
             //act
-            _lanService.StartDequeue();
+            _lanService.StartBroadcast();
             //assert
             _mockLanRepository.VerifySet(lr => lr.DequeueTask = It.IsAny<Task>());
         }

--- a/Library.Tests/Broadcast/LanService_WhenQueueNotEmptyAndPaused_Should.cs
+++ b/Library.Tests/Broadcast/LanService_WhenQueueNotEmptyAndPaused_Should.cs
@@ -15,9 +15,11 @@ namespace Library.Tests.Broadcast
         public LanService_WhenQueueNotEmptyAndPaused_Should()
         {
             _mockLanRepository = new Mock<ILanRepository>();
-            _mockLanRepository.SetupGet(lr => lr.QueueIsEmpty)
+            _mockLanRepository
+                .SetupGet(lr => lr.QueueIsEmpty)
                 .Returns(false);
-            _mockLanRepository.Setup(lr => lr.PopQueue())
+            _mockLanRepository
+                .Setup(lr => lr.PopQueue())
                 .Returns(It.IsAny<byte[]>);
 
             _mockBroadcastThrottleService = new Mock<IBroadcastThrottleService>();
@@ -31,6 +33,7 @@ namespace Library.Tests.Broadcast
         public void QueueInsteadOfBroadcast()
         {
             //assemble
+            _mockLanRepository.ResetCalls();
             var expectedBytes = new byte[] {124};
 
             //act

--- a/Library.Tests/Broadcast/LanService_WhenQueueNotEmpty_Should.cs
+++ b/Library.Tests/Broadcast/LanService_WhenQueueNotEmpty_Should.cs
@@ -82,17 +82,14 @@ namespace Library.Tests.Broadcast
         }
 
         [Fact]
-        public void Broadcast_WillNotStartDequeueTask()
+        public void StartBroadcast_ReturnsNewTask()
         {
             //assemble
-            _mockLanRepository.ResetCalls();
 
             //act
-            _lanService.Broadcast(It.IsAny<byte[]>());
-
+            Task actual = _lanService.StartBroadcast();
             //assert
-            _mockLanRepository.VerifySet(lr=>lr.DequeueTask=It.IsAny<Task>(), 
-                Times.Never);
+            Assert.False(actual.IsCompleted);
         }
     }
 }

--- a/Library.Tests/Broadcast/LanService_WhenQueueNotEmpty_Should.cs
+++ b/Library.Tests/Broadcast/LanService_WhenQueueNotEmpty_Should.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Library.Broadcast;
 using Library.Throttle;
@@ -6,24 +7,38 @@ using Xunit;
 
 namespace Library.Tests.Broadcast
 {
-    public class LanService_WhenQueueNotEmpty_Should
+    public class LanService_WhenQueueNotEmptyAndDequeueStarted_Should
     {
         private readonly LanService _lanService;
         private readonly Mock<ILanRepository> _mockLanRepository;
         private readonly Mock<IBroadcastThrottleService> _mockBroadcastThrottleService;
-        
-        public LanService_WhenQueueNotEmpty_Should()
+        private readonly Task _dequeueTask;
+
+        public LanService_WhenQueueNotEmptyAndDequeueStarted_Should()
         {
             _mockLanRepository = new Mock<ILanRepository>();
-            _mockLanRepository.SetupGet(lr => lr.QueueIsEmpty)
-                .Returns(false);
-            _mockLanRepository.Setup(lr => lr.PopQueue())
+            _mockLanRepository
+                .SetupGet(lr => lr.QueueIsEmpty)
+                .Returns(false); 
+            _mockLanRepository
+                .Setup(lr => lr.PopQueue())
                 .Returns(It.IsAny<byte[]>);
+            _dequeueTask = Task.Run(async ()=>
+            {
+                while (true)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            });
+            _mockLanRepository
+                .SetupGet(lr => lr.DequeueTask)
+                .Returns(_dequeueTask); //the mock task is already started, and will not complete during our tests
 
             _mockBroadcastThrottleService = new Mock<IBroadcastThrottleService>();
             _mockBroadcastThrottleService
                 .SetupGet(bs => bs.Paused)
                 .Returns(false);
+
             _lanService = new LanService(_mockLanRepository.Object, _mockBroadcastThrottleService.Object);
         }
         
@@ -31,7 +46,7 @@ namespace Library.Tests.Broadcast
         public void Dequeue_WillCallRecord()
         {
             //assemble
-
+            _mockBroadcastThrottleService.ResetCalls();
 
             //act
             _lanService.Dequeue();
@@ -44,7 +59,7 @@ namespace Library.Tests.Broadcast
         public void Dequeue_WillCallRepositoryBroadcast()
         {
             //assemble
-
+            _mockLanRepository.ResetCalls();
 
             //act
             _lanService.Dequeue();
@@ -54,16 +69,30 @@ namespace Library.Tests.Broadcast
         }
 
         [Fact]
-        public void ShouldDequeue_WillBeTrue()
+        public void DequeueInProgress_WillBeTrue()
         {
             //assemble
             const bool expected = true;
 
             //act
-            var actual = _lanService.ShouldDequeue;
+            var actual = _lanService.DequeueInProgress;
 
             //assert
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void Broadcast_WillNotStartDequeueTask()
+        {
+            //assemble
+            _mockLanRepository.ResetCalls();
+
+            //act
+            _lanService.Broadcast(It.IsAny<byte[]>());
+
+            //assert
+            _mockLanRepository.VerifySet(lr=>lr.DequeueTask=It.IsAny<Task>(), 
+                Times.Never);
         }
     }
 }

--- a/Library.Tests/Broadcast/LanService_WhenThrottled_Should.cs
+++ b/Library.Tests/Broadcast/LanService_WhenThrottled_Should.cs
@@ -19,7 +19,8 @@ namespace Library.Tests.Broadcast
         public LanService_WhenThrottled_Should()
         {
             _mockLanRepository = new Mock<ILanRepository>();
-            _mockLanRepository.Setup(lr => lr.Broadcast(It.IsAny<byte []>()))
+            _mockLanRepository
+                .Setup(lr => lr.Broadcast(It.IsAny<byte []>()))
                 .Returns(Task.CompletedTask);
             _mockLanRepository
                 .SetupGet(lr => lr.QueueIsEmpty)
@@ -39,7 +40,7 @@ namespace Library.Tests.Broadcast
         public void Broadcast_WillNotCallBroadcast()
         {
             //assemble
-
+            _mockLanRepository.ResetCalls();
 
             //act
             _lanService.Broadcast(It.IsAny<byte[]>());
@@ -52,7 +53,7 @@ namespace Library.Tests.Broadcast
         public void Broadcast_GetsQueued()
         {
             //assemble
-
+            _mockLanRepository.ResetCalls();
 
             //act
             _lanService.Broadcast(It.IsAny<byte[]>());

--- a/Library.Tests/Library.Tests.csproj
+++ b/Library.Tests/Library.Tests.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="Moq" Version="4.7.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/Library/Broadcast/ILanRepository.cs
+++ b/Library/Broadcast/ILanRepository.cs
@@ -15,5 +15,9 @@ namespace Library.Broadcast
         void AddToQueue(byte[] broadcast);
         byte[] PopQueue();
         bool QueueIsEmpty { get; }
+        /// <summary>
+        /// Represents the loop which dequeues continuously. This should be initialized to Task.CompletedTask and therefor never be null.
+        /// </summary>
+        Task DequeueTask { get; set; }
     }
 }

--- a/Library/Broadcast/ILanService.cs
+++ b/Library/Broadcast/ILanService.cs
@@ -7,7 +7,23 @@ namespace Library.Broadcast
     /// </summary>
     public interface ILanService
     {
-        Task Broadcast(byte[] bytes);
+        /// <summary>
+        /// Adds bytes to the queue of bytes to be broadcast. Call StartBroadcast to begin transmitting
+        /// </summary>
+        /// <param name="bytes"></param>
+        /// <returns></returns>
+        void Broadcast(byte[] bytes);
+
+        /// <summary>
+        /// True when the broadcast queue is being drained. False when the queue is empty or broadcasting has been paused.
+        /// </summary>
         bool DequeueInProgress { get; }
+
+        /// <summary>
+        /// Starts a task which will continuously dequeue from the repository. The task ends when the queue is empty or the throttle service becomes paused
+        /// </summary>
+        /// <returns>The new task that was created</returns>
+        /// <exception cref="">Throws an exception is the task is already in progress</exception>
+        Task StartBroadcast();
     }
 }

--- a/Library/Broadcast/ILanService.cs
+++ b/Library/Broadcast/ILanService.cs
@@ -8,5 +8,6 @@ namespace Library.Broadcast
     public interface ILanService
     {
         Task Broadcast(byte[] bytes);
+        bool DequeueInProgress { get; }
     }
 }

--- a/Library/Broadcast/LanRepository.cs
+++ b/Library/Broadcast/LanRepository.cs
@@ -23,6 +23,7 @@ namespace Library.Broadcast
         }
 
         public bool QueueIsEmpty => !q.Any();
+        public Task DequeueTask { get; set; }
 
         public Task Broadcast(byte[] data)
         {

--- a/Library/Broadcast/LanService.cs
+++ b/Library/Broadcast/LanService.cs
@@ -34,17 +34,16 @@ namespace Library.Broadcast
             }
         }
 
-        public Task Broadcast(byte[] bytes)
+        public void Broadcast(byte[] bytes)
         {
             if (_broadcastThrottleService.Paused)
             {
                 _lanRepository.AddToQueue(bytes);
-                return null; //this is a problem for tomorrow Paz
             }
             else
             {
                 _broadcastThrottleService.Record();
-                return _lanRepository.Broadcast(bytes);
+                _lanRepository.Broadcast(bytes);
             }
         }
 
@@ -60,12 +59,7 @@ namespace Library.Broadcast
             _lanRepository.Broadcast(t);
         }
 
-        /// <summary>
-        /// Starts a task which will continuously dequeue from the repository. The task ends when the queue is empty or the throttle service becomes paused
-        /// </summary>
-        /// <returns>The new task that was created</returns>
-        /// <exception cref="">Throws an exception is the task is already in progress</exception>
-        public Task StartDequeue()
+        public Task StartBroadcast()
         {
             throw new NotImplementedException();
         }

--- a/Library/Broadcast/LanService.cs
+++ b/Library/Broadcast/LanService.cs
@@ -8,12 +8,15 @@ namespace Library.Broadcast
     {
         private readonly ILanRepository _lanRepository;
         private readonly IBroadcastThrottleService _broadcastThrottleService;
+        [Obsolete("This task is now located on the repository. This should be removed.")]
         private readonly Task _DrainQueue;
 
         public LanService(ILanRepository lanRepository, IBroadcastThrottleService broadcastThrottleService)
         {
             _lanRepository = lanRepository;
             _broadcastThrottleService = broadcastThrottleService;
+
+            //we are going to start the task when broadcast is called, if the task is not allready started, so we dont need this here.
             _DrainQueue = Task.Run(async () => {
                 while (ShouldDequeue)
                 {
@@ -45,12 +48,26 @@ namespace Library.Broadcast
             }
         }
 
+        [Obsolete("Depricated. This should be removed.")]
         public bool ShouldDequeue => !_broadcastThrottleService.Paused && !_lanRepository.QueueIsEmpty;
+
+        public bool DequeueInProgress => throw new NotImplementedException();
+
         public void Dequeue()
         {
             var t = _lanRepository.PopQueue();
             _broadcastThrottleService.Record();
             _lanRepository.Broadcast(t);
+        }
+
+        /// <summary>
+        /// Starts a task which will continuously dequeue from the repository. The task ends when the queue is empty or the throttle service becomes paused
+        /// </summary>
+        /// <returns>The new task that was created</returns>
+        /// <exception cref="">Throws an exception is the task is already in progress</exception>
+        public Task StartDequeue()
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ Local Area Network Broadcaster
 ## TL;DR
 Broadcasts data over a LAN for maximum throughput. However, the price we pay for this speed is the reliability of knowing if each listener has received all the data and that the data has not been corrupted. The broadcaster and listeners will have to provide a way to check the data and fill in the gaps.
 
+## What's new
+
+### This version
+* Broadcast Logic
+  * Throttling / Queuing
+  * First-draft protocol implementation
+  * Paged reads from disk
+
+### Upcoming 
+* v 0.2
+  * Listen Logic
+
+### Further out 
+* v 0.9 
+  * Performance review
+  * Security review
+  * Network impact review
+* Post v1.0
+  * Grouping protocol messages into "chunks"
+  * Adding data verification at the payload/chunk/file/broadcast level
+  * Signing data at the payload/chunk/file/broadcast level
+
 ## Technical Detail
 This program fills a very niche need: When a group of local area clients need a copy of the same data at the maximum theoretical rate. We use UDP broadcasts to distribute data. UDP broadcasts will not be forwarded by most routers, therefore this traffic will only be visible within a Local Area Network. UDP does not ensure delivery, order of arrival, or verification. This program will tolerate some late delivery, and will throw out any protocol critical data that has been corrupted. Otherwise, listeners are left to their own interpretation. It is beyond the scope of this program to handle detection of corrupted payload data and the retransmission of that data. 
 ## Security concerns
@@ -22,3 +44,6 @@ We intend the default method of "filling in the gaps" (missing or bad data) is g
 * One broadcaster broadcasts the entirety of her message
 * Listeners acquire and download a .torrent which is seeded by the broadcaster
   - BitTorrent will handle identifying missing or bad data. It will also take advantage of the fact that different listeners might have successfully received different parts of the broadcast.
+
+
+


### PR DESCRIPTION
Primarily dealt with LanService tests.

Note the required .ResetCalls(). This was a subtle bug in the original code. Without these lines, repeated calls would interfere between tests. 

I also updated some packages on the Test project. This should have been a separate commit, but oh well.